### PR TITLE
NOISSUE: Fix jcenter breaking and making everything in it be compiled…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.6-SNAPSHOT'
+	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'


### PR DESCRIPTION
… with java 11, breaking attempts to compile with java 8

Fix gotten from [geckolib@b4cf083](https://github.com/bernie-g/geckolib/commit/b4cf083bfdbfd4dccda8aea66474679083d069d5)